### PR TITLE
feat: add electron desktop app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+tools/installer/node_modules/
+.npm/
+npm-debug.log*
+.DS_Store
+desktop/electron/dist/
+desktop/electron/out/
+dist/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,39 +1,151 @@
-# 安装和使用指南
+# 配置、安装与测试指南
 
-## 方式1: NPM全局安装
+本文档提供从零开始部署 BMAD Research Framework 的完整流程，涵盖本地开发环境准备、依赖安装、配置 SaaS 服务以及运行内置校验测试的步骤。
 
-```bash
-npm install -g bmad-research-framework
-research-framework install /path/to/your/project
-```
+## 1. 环境准备
 
-## 方式2: NPX直接使用
+在开始之前，请确保满足以下要求：
 
-```bash
-npx bmad-research-framework install
-```
+- **操作系统**：macOS、Linux 或 Windows（需具备 Node.js 运行环境）
+- **Node.js**：>= 20.10.0（与 `package.json` 中的 `engines` 字段保持一致）
+- **npm**：建议使用 npm v10 及以上版本
+- **Git**：用于克隆仓库
 
-## 方式3: 本地项目安装
+检查版本：
 
 ```bash
-npm install bmad-research-framework
-npx bmad-research-framework install
+node -v
+npm -v
+git --version
 ```
 
-## 使用示例
+## 2. 获取项目代码
 
-在Claude Code或任何支持BMAD的环境中：
+通过 Git 克隆仓库后进入项目目录：
 
-```markdown
-我想开始一个关于"机器学习在医学影像中的应用"的研究项目。
-
-@research-strategy-planner
+```bash
+git clone https://github.com/YOUR_ORG/bmad-research-framework.git
+cd bmad-research-framework
 ```
 
-系统将自动：
-1. 分析项目需求
-2. 配置专业智能体团队  
-3. 进行文献调研
-4. 撰写申请报告
-5. 执行研究流程
-6. 生成研究报告
+如果已经拥有仓库，可通过 `git pull` 更新到最新代码。
+
+## 3. 安装依赖
+
+项目包含 CLI 工具与 SaaS 在线服务，两者共享同一套依赖。执行以下命令安装：
+
+```bash
+npm install
+```
+
+安装成功后将生成 `node_modules/` 目录，并为 CLI 与 SaaS 服务准备好运行环境。
+
+> **提示**：在受限网络环境中，可配置企业私有 npm 镜像或提前下载依赖包，确保安装顺利完成。
+
+## 4. 核心配置
+
+大部分功能可在默认配置下运行，但以下环境变量可以根据需要覆盖：
+
+| 变量名 | 作用 | 默认值 |
+| ------ | ---- | ------ |
+| `BMAD_ROOT` | 指定框架根目录，供 SaaS 服务读取核心数据 | 仓库根目录 |
+| `HOST` | SaaS 服务监听地址 | `0.0.0.0` |
+| `PORT` | SaaS 服务端口 | `3000` |
+
+配置方式示例：
+
+```bash
+export BMAD_ROOT="/path/to/bmad-research-framework"
+export HOST="127.0.0.1"
+export PORT="4000"
+```
+
+## 5. 构建与校验
+
+框架提供两项关键的质量校验命令：
+
+```bash
+npm test           # 依次执行构建与验证流程
+# 或单独运行：
+npm run build      # 执行框架构建流程
+npm run validate   # 运行内置验证，确保配置与元数据一致
+```
+
+建议在每次提交代码前运行 `npm test`，确认升级工具、元数据与服务接口均处于健康状态；如需单独排查，可分别执行 `build` 或 `validate`。
+
+## 6. 运行 SaaS 在线服务
+
+安装与构建完成后，可启动 Express SaaS 服务，将框架能力以 HTTP API 的形式对外提供：
+
+```bash
+npm run start:saas
+```
+
+服务默认监听 `http://0.0.0.0:3000`，启动后可在终端看到 `BMAD Research SaaS listening...` 的日志输出。
+
+### 6.1 常用接口
+
+- `GET /health`：健康检查
+- `GET /api/catalog/agents`：获取智能体列表
+- `GET /api/catalog/workflows`：查询工作流配置
+- `POST /api/projects`：根据输入生成项目规划
+
+示例请求：
+
+```bash
+curl http://localhost:3000/health
+
+curl http://localhost:3000/api/catalog/agents
+
+curl -X POST http://localhost:3000/api/projects \
+  -H "Content-Type: application/json" \
+  -d '{
+        "projectName": "AI 辅助药物设计",
+        "researchType": "应用研究",
+        "objectives": ["药物筛选", "模型评估"]
+      }'
+```
+
+## 7. 运行桌面版 Electron 应用
+
+桌面版本提供与 SaaS 完全独立的本地体验。首次使用前需安装桌面端依赖：
+
+```bash
+cd desktop/electron
+npm install
+```
+
+随后可通过根目录提供的脚本直接启动应用：
+
+```bash
+npm run start:desktop
+```
+
+若需启用更详细的日志，可执行 `npm run start:desktop:dev`。桌面程序默认读取当前仓库的核心与扩展包数据，无需启动 SaaS 服务即可离线生成项目计划。
+
+## 8. 运行 CLI 功能（可选）
+
+框架仍可作为命令行工具使用，以下示例展示如何在本地项目中初始化：
+
+```bash
+npx research-framework install ./my-research-project
+```
+
+CLI 会引导完成扩展包安装、研究流程初始化等步骤，可与 SaaS 服务并行使用。
+
+## 9. 测试完成后的期望结果
+
+完成上述步骤后，应能获得以下结果：
+
+1. `npm install` 无报错，依赖安装完毕。
+2. `npm run build`、`npm run validate` 均以退出码 0 结束。
+3. 执行 `npm run start:saas` 后浏览器或 `curl` 请求能获得有效响应。
+4. 可选：`npx research-framework install` 能在新目录中生成框架模板。
+
+## 10. 常见问题排查
+
+- **依赖安装失败**：检查网络环境或使用企业私有镜像；必要时可手动下载 tarball 后使用 `npm install <path-to-tarball>`。
+- **SaaS 服务无法读取数据**：确认 `BMAD_ROOT` 指向仓库根目录，且该目录下的 `bmad-core/` 与 `expansion-packs/` 完整存在。
+- **端口被占用**：修改 `PORT` 环境变量或停止占用端口的进程。
+
+按照本指南完成配置后，BMAD Research Framework 即可在本地或服务器环境稳定运行，并通过 SaaS 或 CLI 形态提供科研智能体能力。

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ research-framework install
 # 在Claude Code中激活：@research-strategy-planner
 ```
 
+## 运行方式
+
+- 🌐 **SaaS 在线服务**：`npm run start:saas` 启动 Express API，适合部署到服务器供团队协同使用。
+- 🖥️ **Electron 桌面版**：`npm run start:desktop` 启动本地独立界面，无需联网即可浏览目录并生成项目计划。
+
 ## 支持的研究类型
 
 - ✅ 国家自然科学基金申请

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -1,0 +1,46 @@
+# BMAD Research Framework · Electron 桌面版
+
+该目录提供与 SaaS 服务完全独立的 Electron 桌面应用，支持在本地环境离线浏览智能体目录、查看扩展包、并生成研究项目计划。
+
+## 功能特性
+
+- 离线浏览核心与扩展包智能体、团队与工作流概览
+- 查看单个智能体的命令、依赖、推荐使用场景与角色描述
+- 基于工作流生成项目计划，包含阶段安排、交付物与沟通节点
+- 轻量级偏好存储：窗口尺寸、主题选择（浅色 / 深色 / 跟随系统）
+
+## 安装依赖
+
+```bash
+cd desktop/electron
+npm install
+```
+
+> ⚠️ 在封闭网络环境下安装 Electron 可能失败，可参考 `INSTALL.md` 中的离线安装指引或使用本地镜像源。
+
+## 开发与调试
+
+```bash
+npm start          # 启动正式模式
+npm run start:dev  # 启用日志的调试模式
+```
+
+应用会自动读取仓库根目录下的 `bmad-core/` 与 `expansion-packs/` 数据，无需启动 SaaS 服务。
+
+## 打包
+
+```bash
+npm run package
+```
+
+默认使用 `electron-builder` 生成平台安装包，可在 `package.json` 中调整配置。
+
+## 目录结构
+
+```
+desktop/electron/
+├─ main.js          # Electron 主进程，注册 IPC 与服务实例
+├─ preload.js       # 预加载脚本，将后台能力暴露给渲染层
+├─ renderer/        # 渲染进程静态页面与脚本
+└─ package.json     # 桌面应用独立依赖与脚本
+```

--- a/desktop/electron/main.js
+++ b/desktop/electron/main.js
@@ -1,0 +1,128 @@
+const path = require('node:path');
+const { app, BrowserWindow, ipcMain, nativeTheme } = require('electron');
+const Store = require('electron-store');
+
+const createCatalogService = require(path.join(__dirname, '..', '..', 'services', 'saas', 'src', 'services', 'catalog-service'));
+const createProjectService = require(path.join(__dirname, '..', '..', 'services', 'saas', 'src', 'services', 'project-service'));
+
+const store = new Store({ name: 'bmad-desktop-preferences' });
+
+const rootDir = path.resolve(__dirname, '..', '..');
+const catalogService = createCatalogService({ rootDir });
+const projectService = createProjectService({ rootDir, catalogService });
+let handlersRegistered = false;
+
+function ensureHandlers() {
+  if (handlersRegistered) return;
+  handlersRegistered = true;
+
+  nativeTheme.themeSource = store.get('theme', 'system');
+
+  ipcMain.handle('preferences:get', () => {
+    return {
+      theme: store.get('theme', 'system'),
+    };
+  });
+
+  ipcMain.handle('preferences:set-theme', (_event, theme) => {
+    if (!['light', 'dark', 'system'].includes(theme)) return;
+    store.set('theme', theme);
+    nativeTheme.themeSource = theme;
+  });
+
+  ipcMain.handle('catalog:overview', async () => {
+    const [agents, teams, workflows, expansions] = await Promise.all([
+      catalogService.listAgents(),
+      catalogService.listTeams(),
+      catalogService.listWorkflows(),
+      catalogService.listExpansions(),
+    ]);
+
+    return {
+      agentCount: agents.length,
+      teamCount: teams.length,
+      workflowCount: workflows.length,
+      agents,
+      teams,
+      workflows,
+      expansions,
+      sources: [
+        { type: 'core', source: 'core', name: '核心能力', version: null },
+        ...expansions.map((pack) => ({
+          type: 'expansion',
+          source: `expansion:${pack.id}`,
+          packId: pack.id,
+          name: pack.name,
+          version: pack.version,
+          description: pack.description,
+        })),
+      ],
+    };
+  });
+
+  ipcMain.handle('catalog:agent-detail', async (_event, agentId) => {
+    return catalogService.getAgent(agentId);
+  });
+
+  ipcMain.handle('projects:generate-plan', async (_event, payload) => {
+    return projectService.createProjectPlan(payload);
+  });
+
+  ipcMain.handle('projects:list-workflows', async () => {
+    return catalogService.listWorkflows();
+  });
+
+  ipcMain.handle('catalog:list-expansions', async () => {
+    return catalogService.listExpansions();
+  });
+
+  return;
+}
+
+async function createWindow() {
+  ensureHandlers();
+  const windowState = store.get('windowState', { width: 1260, height: 840 });
+
+  const win = new BrowserWindow({
+    width: windowState.width,
+    height: windowState.height,
+    minWidth: 960,
+    minHeight: 640,
+    title: 'BMAD Research Framework — Desktop',
+    autoHideMenuBar: true,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  if (windowState.x !== undefined && windowState.y !== undefined) {
+    win.setBounds({ ...win.getBounds(), x: windowState.x, y: windowState.y });
+  }
+
+  win.on('close', () => {
+    const bounds = win.getBounds();
+    store.set('windowState', bounds);
+  });
+
+  await win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+  return win;
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "bmad-research-desktop",
+  "version": "1.0.0",
+  "description": "Electron 桌面版 BMAD 研究框架，提供离线浏览与项目规划能力。",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "start:dev": "ELECTRON_ENABLE_LOGGING=true electron .",
+    "package": "electron-builder"
+  },
+  "dependencies": {
+    "electron-store": "^9.0.0"
+  },
+  "devDependencies": {
+    "electron": "^31.0.2",
+    "electron-builder": "^24.13.3"
+  },
+  "build": {
+    "appId": "org.bmad.research.desktop",
+    "productName": "BMAD Research Desktop",
+    "files": [
+      "main.js",
+      "preload.js",
+      "renderer/**/*"
+    ]
+  }
+}

--- a/desktop/electron/preload.js
+++ b/desktop/electron/preload.js
@@ -1,0 +1,11 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('bmadDesktop', {
+  loadOverview: () => ipcRenderer.invoke('catalog:overview'),
+  listWorkflows: () => ipcRenderer.invoke('projects:list-workflows'),
+  listExpansions: () => ipcRenderer.invoke('catalog:list-expansions'),
+  getAgentDetail: (agentId) => ipcRenderer.invoke('catalog:agent-detail', agentId),
+  generatePlan: (payload) => ipcRenderer.invoke('projects:generate-plan', payload),
+  getPreferences: () => ipcRenderer.invoke('preferences:get'),
+  setTheme: (theme) => ipcRenderer.invoke('preferences:set-theme', theme),
+});

--- a/desktop/electron/renderer/index.html
+++ b/desktop/electron/renderer/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BMAD Research Framework 桌面版</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="branding">
+        <h1>BMAD Research Framework</h1>
+        <p class="subtitle">桌面版 · 离线科研协同控制台</p>
+      </div>
+      <div class="toolbar">
+        <label for="theme-select">主题：</label>
+        <select id="theme-select">
+          <option value="system">跟随系统</option>
+          <option value="light">浅色</option>
+          <option value="dark">深色</option>
+        </select>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="panel catalog-panel">
+        <h2>Agent 与团队目录</h2>
+        <div class="catalog-summary">
+          <div>
+            <span class="summary-value" id="agent-count">0</span>
+            <span class="summary-label">智能体</span>
+          </div>
+          <div>
+            <span class="summary-value" id="team-count">0</span>
+            <span class="summary-label">团队</span>
+          </div>
+          <div>
+            <span class="summary-value" id="workflow-count">0</span>
+            <span class="summary-label">工作流</span>
+          </div>
+        </div>
+        <div class="catalog-filters">
+          <label for="expansion-filter">扩展包：</label>
+          <select id="expansion-filter">
+            <option value="all">全部</option>
+          </select>
+        </div>
+        <ul id="agent-list" class="agent-list"></ul>
+      </section>
+
+      <section class="panel detail-panel">
+        <h2>智能体详情</h2>
+        <article id="agent-detail" class="detail-card">
+          <p class="placeholder">请选择左侧的智能体以查看详细信息。</p>
+        </article>
+      </section>
+
+      <section class="panel planner-panel">
+        <h2>项目规划</h2>
+        <form id="planner-form" class="planner-form">
+          <label>
+            研究主题
+            <input type="text" id="project-title" placeholder="例如：AI 在医学影像中的应用" required />
+          </label>
+          <label>
+            研究类型
+            <input type="text" id="project-type" placeholder="基础研究 / 应用研究 / 社科" />
+          </label>
+          <label>
+            研究目标
+            <textarea id="project-objectives" rows="3" placeholder="多条目标可用换行分隔"></textarea>
+          </label>
+          <label>
+            期望团队规模
+            <input type="number" id="team-size" min="1" placeholder="默认自动匹配" />
+          </label>
+          <label>
+            工作流
+            <select id="workflow-select"></select>
+          </label>
+          <button type="submit">生成项目计划</button>
+        </form>
+        <section id="plan-output" class="plan-output hidden"></section>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>BMAD Research Framework © 当前工作区</p>
+    </footer>
+
+    <script src="index.js" type="module"></script>
+  </body>
+</html>

--- a/desktop/electron/renderer/index.js
+++ b/desktop/electron/renderer/index.js
@@ -1,0 +1,290 @@
+const agentListEl = document.getElementById('agent-list');
+const agentDetailEl = document.getElementById('agent-detail');
+const agentCountEl = document.getElementById('agent-count');
+const teamCountEl = document.getElementById('team-count');
+const workflowCountEl = document.getElementById('workflow-count');
+const expansionFilterEl = document.getElementById('expansion-filter');
+const themeSelectEl = document.getElementById('theme-select');
+const plannerForm = document.getElementById('planner-form');
+const workflowSelect = document.getElementById('workflow-select');
+const planOutputEl = document.getElementById('plan-output');
+const projectTitleEl = document.getElementById('project-title');
+const projectTypeEl = document.getElementById('project-type');
+const projectObjectivesEl = document.getElementById('project-objectives');
+const teamSizeEl = document.getElementById('team-size');
+
+let catalogOverview = null;
+let workflows = [];
+
+async function initialise() {
+  try {
+    const preferences = await window.bmadDesktop.getPreferences();
+    if (preferences?.theme && ['light', 'dark', 'system'].includes(preferences.theme)) {
+      themeSelectEl.value = preferences.theme;
+    }
+    catalogOverview = await window.bmadDesktop.loadOverview();
+    workflows = await window.bmadDesktop.listWorkflows();
+    renderCatalog(catalogOverview);
+    renderWorkflows(workflows);
+    populateExpansions(catalogOverview.sources);
+  } catch (error) {
+    renderError(error);
+  }
+}
+
+function renderCatalog(overview) {
+  agentCountEl.textContent = overview.agentCount;
+  teamCountEl.textContent = overview.teamCount;
+  workflowCountEl.textContent = overview.workflowCount;
+  renderAgentList(overview.agents);
+}
+
+function populateExpansions(sources = []) {
+  expansionFilterEl.innerHTML = '<option value="all">全部</option>';
+  const coreOption = document.createElement('option');
+  coreOption.value = 'core';
+  coreOption.textContent = '核心库';
+  expansionFilterEl.appendChild(coreOption);
+  sources
+    .filter((source) => source.type === 'expansion')
+    .forEach((source) => {
+      const option = document.createElement('option');
+      option.value = source.packId;
+      option.textContent = `${source.name} v${source.version || 'N/A'}`;
+      expansionFilterEl.appendChild(option);
+    });
+}
+
+function renderAgentList(agents) {
+  const selectedPack = expansionFilterEl.value;
+  agentListEl.innerHTML = '';
+
+  agents
+    .filter((agent) => {
+      if (selectedPack === 'all') return true;
+      if (selectedPack === 'core') return agent.source === 'core';
+      return agent.expansionPack === selectedPack;
+    })
+    .forEach((agent) => {
+      const item = document.createElement('li');
+      item.dataset.agentId = agent.id;
+      item.innerHTML = `
+        <div class="agent-title">${agent.name}</div>
+        <div class="agent-role">${agent.role || '通用智能体'}</div>
+        <div class="agent-meta">
+          <span class="badge">${agent.source === 'core' ? '核心' : agent.expansionPack}</span>
+          <span class="badge">指令 ${agent.commandCount}</span>
+        </div>
+      `;
+      item.addEventListener('click', () => selectAgent(agent.id));
+      agentListEl.appendChild(item);
+    });
+}
+
+async function selectAgent(agentId) {
+  agentListEl.querySelectorAll('li').forEach((li) => {
+    li.classList.toggle('active', li.dataset.agentId === agentId);
+  });
+
+  try {
+    const agent = await window.bmadDesktop.getAgentDetail(agentId);
+    renderAgentDetail(agent);
+  } catch (error) {
+    agentDetailEl.innerHTML = `<p class="placeholder">加载智能体详情失败：${error.message}</p>`;
+  }
+}
+
+function renderAgentDetail(agent) {
+  if (!agent) {
+    agentDetailEl.innerHTML = '<p class="placeholder">未找到该智能体。</p>';
+    return;
+  }
+
+  const dependencies = Object.entries(agent.dependencySummary || {})
+    .filter(([key]) => key !== 'totalCount')
+    .map(([key, value]) => `<li>${key}：${value.items.join('、')}</li>`)
+    .join('');
+
+  const commands = agent.commands
+    .map((command) => `<li><strong>${command.command}</strong> — ${command.description || '无描述'}</li>`)
+    .join('');
+
+  agentDetailEl.innerHTML = `
+    <h3>${agent.name}</h3>
+    <p class="agent-role">${agent.title || agent.role || '通用智能体'}</p>
+    <section>
+      <h4>简介</h4>
+      <p>${agent.summary || '该智能体尚未提供简介。'}</p>
+    </section>
+    <section>
+      <h4>职责</h4>
+      <p>${agent.focus || '暂无专长描述。'}</p>
+    </section>
+    <section>
+      <h4>推荐使用场景</h4>
+      <p>${agent.whenToUse || '未提供使用建议。'}</p>
+    </section>
+    <section>
+      <h4>命令与操作</h4>
+      <ul>${commands || '<li>暂无指令</li>'}</ul>
+    </section>
+    <section>
+      <h4>依赖总结</h4>
+      <ul>${dependencies || '<li>无其他依赖</li>'}</ul>
+    </section>
+  `;
+}
+
+function renderWorkflows(workflowsList) {
+  workflowSelect.innerHTML = '';
+  workflowsList.forEach((workflow) => {
+    const option = document.createElement('option');
+    option.value = workflow.id;
+    const phaseCount = Array.isArray(workflow.phases) ? workflow.phases.length : 0;
+    option.textContent = `${workflow.name}（${phaseCount} 阶段）`;
+    workflowSelect.appendChild(option);
+  });
+}
+
+function renderPlan(plan) {
+  planOutputEl.classList.remove('hidden');
+  const project = plan.project || {};
+  const profile = project.profile || {};
+  const team = plan.recommendedTeam || {};
+  const scaling = team.scalingRecommendation || {};
+  const workflow = plan.workflowPlan || {};
+  const knowledge = plan.knowledgeSupport || {};
+  const phases = Array.isArray(workflow.phases) ? workflow.phases : [];
+  const deliverables = Array.isArray(workflow.deliverables) ? workflow.deliverables : [];
+  const interactionPoints = Array.isArray(workflow.interactionPoints)
+    ? workflow.interactionPoints
+    : [];
+  const nextActions = Array.isArray(plan.nextActions) ? plan.nextActions : [];
+  const focusAreas = [
+    ...(Array.isArray(profile.metrics) ? profile.metrics : []),
+    ...(Array.isArray(profile.riskFocus) ? profile.riskFocus : []),
+    ...(profile.knowledgeFocus ? [profile.knowledgeFocus] : []),
+  ];
+
+  planOutputEl.innerHTML = `
+    <h3>${project.name || '科研项目规划'}</h3>
+    <p class="plan-summary">${profile.summary || '该研究类型暂无补充摘要。'}</p>
+
+    <div class="plan-section">
+      <h4>研究重点</h4>
+      <ul class="plan-list">
+        ${focusAreas.length ? focusAreas.map((focus) => `<li>${focus}</li>`).join('') : '<li>该研究类型未提供额外侧重点。</li>'}
+      </ul>
+    </div>
+
+    <div class="plan-section">
+      <h4>推荐团队</h4>
+      <p><strong>${team.name || '未指定团队'}</strong></p>
+      <p>${team.description || '暂无团队描述。'}</p>
+      <p>${scaling.rationale || '采用默认团队配置。'}</p>
+    </div>
+
+    <div class="plan-section">
+      <h4>阶段安排</h4>
+      ${
+        phases.length
+          ? phases
+              .map(
+                (phase) => `
+              <article class="phase-card">
+                <h5>${phase.name}</h5>
+                <p>${phase.description || '无描述'}</p>
+                <ul class="plan-list">
+                  ${
+                    Array.isArray(phase.steps) && phase.steps.length
+                      ? phase.steps
+                          .map((step) => `<li>${step.name} — <em>${step.agent || '未指派'}</em></li>`)
+                          .join('')
+                      : '<li>该阶段暂无具体步骤。</li>'
+                  }
+                </ul>
+              </article>
+            `,
+              )
+              .join('')
+          : '<p class="placeholder">未找到工作流阶段定义。</p>'
+      }
+    </div>
+
+    <div class="plan-section">
+      <h4>交付物与沟通节点</h4>
+      <h5>交付物</h5>
+      <ul class="plan-list">
+        ${
+          deliverables.length
+            ? deliverables
+                .map((deliverable) => `<li>${deliverable.output}（阶段：${deliverable.phase}）</li>`)
+                .join('')
+            : '<li>该工作流未定义交付物。</li>'
+        }
+      </ul>
+      <h5>沟通节点</h5>
+      <ul class="plan-list">
+        ${
+          interactionPoints.length
+            ? interactionPoints
+                .map((point) => `<li>${point.stepName} — ${point.description}</li>`)
+                .join('')
+            : '<li>该工作流未包含关键沟通节点。</li>'
+        }
+      </ul>
+    </div>
+
+    <div class="plan-section">
+      <h4>知识支持</h4>
+      <p>扩展包：${knowledge.expansionPack?.name || '未指定'}</p>
+      <p>推荐模板：${
+        Array.isArray(knowledge.recommendedTemplates) && knowledge.recommendedTemplates.length
+          ? knowledge.recommendedTemplates.join('、')
+          : '无'
+      }</p>
+      <p>知识侧重点：${knowledge.knowledgeFocus || profile.knowledgeFocus || '未提供'}</p>
+    </div>
+
+    <div class="plan-section">
+      <h4>下一步行动</h4>
+      <ul class="plan-list">
+        ${nextActions.length ? nextActions.map((action) => `<li>${action}</li>`).join('') : '<li>暂无建议的后续行动。</li>'}
+      </ul>
+    </div>
+  `;
+}
+
+function renderError(error) {
+  agentDetailEl.innerHTML = `<p class="placeholder">加载目录失败：${error.message}</p>`;
+}
+
+expansionFilterEl.addEventListener('change', () => {
+  if (!catalogOverview) return;
+  renderAgentList(catalogOverview.agents);
+});
+
+plannerForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  try {
+    const payload = {
+      projectName: projectTitleEl.value,
+      researchType: projectTypeEl.value,
+      objectives: projectObjectivesEl.value,
+      expectedTeamSize: teamSizeEl.value ? Number(teamSizeEl.value) : undefined,
+      workflowId: workflowSelect.value,
+    };
+    const plan = await window.bmadDesktop.generatePlan(payload);
+    renderPlan(plan);
+  } catch (error) {
+    planOutputEl.classList.remove('hidden');
+    planOutputEl.innerHTML = `<p class="placeholder">生成项目计划失败：${error.message}</p>`;
+  }
+});
+
+themeSelectEl.addEventListener('change', () => {
+  const theme = themeSelectEl.value;
+  window.bmadDesktop.setTheme(theme);
+});
+
+initialise();

--- a/desktop/electron/renderer/styles.css
+++ b/desktop/electron/renderer/styles.css
@@ -1,0 +1,254 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f8f9fb;
+  --bg-alt: #ffffff;
+  --border: #d7dbe3;
+  --text: #1b1e28;
+  --text-muted: #5f6676;
+  --accent: #2563eb;
+  --accent-muted: #bfdbfe;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #12141b;
+    --bg-alt: #1f2430;
+    --border: #2d3342;
+    --text: #f4f7ff;
+    --text-muted: #a1acc9;
+    --accent: #60a5fa;
+    --accent-muted: #1e3a8a;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', 'Segoe UI', 'PingFang SC', 'Helvetica Neue', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header,
+.app-footer {
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.app-footer {
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  margin-top: auto;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.toolbar select {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px 1fr 420px;
+  gap: 20px;
+  padding: 20px 24px;
+}
+
+.panel {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.catalog-summary {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.summary-value {
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.summary-label {
+  display: block;
+  color: var(--text-muted);
+}
+
+.catalog-filters {
+  margin-bottom: 12px;
+}
+
+.agent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+}
+
+.agent-list li {
+  padding: 12px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.agent-list li:hover,
+.agent-list li.active {
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.agent-list .agent-title {
+  font-weight: 600;
+}
+
+.agent-list .agent-role {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.detail-card {
+  flex: 1;
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 16px;
+}
+
+.placeholder {
+  color: var(--text-muted);
+  text-align: center;
+  margin-top: 40px;
+}
+
+.detail-card h3 {
+  margin-top: 0;
+}
+
+.detail-card section {
+  margin-bottom: 16px;
+}
+
+.detail-card ul {
+  padding-left: 18px;
+}
+
+.planner-form {
+  display: grid;
+  gap: 12px;
+}
+
+.planner-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 500;
+}
+
+.planner-form input,
+.planner-form textarea,
+.planner-form select {
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.planner-form button {
+  padding: 12px 16px;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--accent), #4f46e5);
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.planner-form button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.25);
+}
+
+.plan-output {
+  margin-top: 16px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  overflow-y: auto;
+}
+
+.plan-output.hidden {
+  display: none;
+}
+
+.plan-output h3 {
+  margin-top: 0;
+}
+
+.plan-section {
+  margin-bottom: 20px;
+}
+
+.plan-section h4 {
+  margin-bottom: 8px;
+}
+
+.plan-list {
+  padding-left: 20px;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent-muted);
+  color: var(--accent);
+  font-size: 0.75rem;
+  margin-right: 6px;
+}
+
+@media (max-width: 1280px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    min-height: 240px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,15 +27,23 @@
   "scripts": {
     "build": "node tools/cli.js build",
     "validate": "node tools/cli.js validate",
-    "install:framework": "node tools/installer/bin/bmad.js install --expansion-packs bmad-research-framework"
+    "test": "npm run build && npm run validate",
+    "install:framework": "node tools/installer/bin/bmad.js install --expansion-packs bmad-research-framework",
+    "start:saas": "node services/saas/src/server.js",
+    "start:desktop": "npm --prefix desktop/electron start",
+    "start:desktop:dev": "npm --prefix desktop/electron run start:dev"
   },
   "dependencies": {
     "chalk": "^4.1.2",
     "commander": "^14.0.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
     "fs-extra": "^11.3.1",
     "glob": "^11.0.3",
     "inquirer": "^8.2.6",
     "js-yaml": "^4.1.0",
+    "helmet": "^7.1.0",
+    "morgan": "^1.10.0",
     "ora": "^5.4.1"
   },
   "engines": {

--- a/services/saas/README.md
+++ b/services/saas/README.md
@@ -1,0 +1,41 @@
+# BMAD Research Framework SaaS 服务
+
+该目录提供将 BMAD Research Framework 封装为在线服务（SaaS）的参考实现，包含可直接运行的 Node.js/Express 服务：
+
+- `/api/catalog`：查询智能体、团队、工作流以及扩展包元数据
+- `/api/projects`：根据研究项目信息自动生成推荐的科研团队与工作流计划
+- `/health`：基础健康检查
+
+## 快速启动
+
+```bash
+npm install
+npm test           # 可选：确保核心构建与配置校验通过
+npm run start:saas
+```
+
+默认监听 `0.0.0.0:3000`，可通过环境变量进行配置：
+
+- `PORT`：服务端口，默认为 `3000`
+- `HOST`：监听地址，默认为 `0.0.0.0`
+- `BMAD_ROOT`：框架根目录，默认推断为仓库根目录
+
+启动后可通过例如以下请求获取数据：
+
+```bash
+curl http://localhost:3000/api/catalog/agents
+curl -X POST http://localhost:3000/api/projects \
+  -H 'Content-Type: application/json' \
+  -d '{"projectName":"AI 辅助药物设计", "researchType":"应用研究"}'
+```
+
+## 结构说明
+
+- `src/app.js`：Express 应用创建，挂载路由与中间件
+- `src/server.js`：服务启动入口
+- `src/routes`：API 路由定义
+- `src/controllers`：请求处理逻辑
+- `src/services`：业务能力（目录/项目规划）
+- `src/utils`：通用工具函数
+
+该服务默认读取仓库中的 `bmad-core` 与 `expansion-packs/bmad-research-framework` 内容，未来可扩展支持更多扩展包或鉴权能力。

--- a/services/saas/src/app.js
+++ b/services/saas/src/app.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const morgan = require('morgan');
+
+const createCatalogRouter = require('./routes/catalog');
+const createProjectsRouter = require('./routes/projects');
+
+async function createApp(options = {}) {
+  const {
+    rootDir = process.cwd(),
+    corsOrigin = '*',
+    trustProxy = false,
+  } = options;
+
+  const app = express();
+  if (trustProxy) {
+    app.set('trust proxy', trustProxy === true ? 1 : trustProxy);
+  }
+
+  app.use(helmet());
+  app.use(cors({ origin: corsOrigin }));
+  app.use(express.json({ limit: '2mb' }));
+  app.use(morgan('dev'));
+
+  const routerOptions = { rootDir };
+
+  app.get('/health', (req, res) => {
+    res.json({ status: 'ok', service: 'bmad-research-saas' });
+  });
+
+  app.use('/api/catalog', createCatalogRouter(routerOptions));
+  app.use('/api/projects', createProjectsRouter(routerOptions));
+
+  app.use((req, res) => {
+    res.status(404).json({ error: 'Not Found', path: req.path });
+  });
+
+  app.use((err, req, res, next) => {
+    // eslint-disable-next-line no-console
+    console.error('SaaS service error:', err);
+    const status = err.status || 500;
+    res.status(status).json({
+      error: err.message || 'Unexpected error',
+      details: err.details,
+    });
+  });
+
+  return app;
+}
+
+module.exports = createApp;

--- a/services/saas/src/controllers/catalog-controller.js
+++ b/services/saas/src/controllers/catalog-controller.js
@@ -1,0 +1,60 @@
+const createCatalogService = require('../services/catalog-service');
+const asyncHandler = require('../utils/async-handler');
+
+module.exports = function createCatalogController(options = {}) {
+  const service = createCatalogService(options);
+
+  return {
+    getOverview: asyncHandler(async (req, res) => {
+      const overview = await service.getOverview();
+      res.json(overview);
+    }),
+
+    listAgents: asyncHandler(async (req, res) => {
+      const agents = await service.listAgents({ source: req.query.source });
+      res.json({ items: agents });
+    }),
+
+    getAgent: asyncHandler(async (req, res) => {
+      const agent = await service.getAgent(req.params.id, req.query.source);
+      if (!agent) {
+        res.status(404).json({ error: `Agent ${req.params.id} not found` });
+        return;
+      }
+      res.json(agent);
+    }),
+
+    listTeams: asyncHandler(async (req, res) => {
+      const teams = await service.listTeams({ source: req.query.source });
+      res.json({ items: teams });
+    }),
+
+    getTeam: asyncHandler(async (req, res) => {
+      const team = await service.getTeam(req.params.id, req.query.source);
+      if (!team) {
+        res.status(404).json({ error: `Team ${req.params.id} not found` });
+        return;
+      }
+      res.json(team);
+    }),
+
+    listWorkflows: asyncHandler(async (req, res) => {
+      const workflows = await service.listWorkflows({ source: req.query.source });
+      res.json({ items: workflows });
+    }),
+
+    getWorkflow: asyncHandler(async (req, res) => {
+      const workflow = await service.getWorkflow(req.params.id, req.query.source);
+      if (!workflow) {
+        res.status(404).json({ error: `Workflow ${req.params.id} not found` });
+        return;
+      }
+      res.json(workflow);
+    }),
+
+    listExpansions: asyncHandler(async (req, res) => {
+      const expansions = await service.listExpansions();
+      res.json({ items: expansions });
+    }),
+  };
+};

--- a/services/saas/src/controllers/projects-controller.js
+++ b/services/saas/src/controllers/projects-controller.js
@@ -1,0 +1,13 @@
+const createProjectService = require('../services/project-service');
+const asyncHandler = require('../utils/async-handler');
+
+module.exports = function createProjectsController(options = {}) {
+  const service = createProjectService(options);
+
+  return {
+    createProjectPlan: asyncHandler(async (req, res) => {
+      const plan = await service.createProjectPlan(req.body || {});
+      res.status(201).json(plan);
+    }),
+  };
+};

--- a/services/saas/src/routes/catalog.js
+++ b/services/saas/src/routes/catalog.js
@@ -1,0 +1,19 @@
+const express = require('express');
+
+const createCatalogController = require('../controllers/catalog-controller');
+
+module.exports = function createCatalogRouter(options = {}) {
+  const router = express.Router();
+  const controller = createCatalogController(options);
+
+  router.get('/', controller.getOverview);
+  router.get('/agents', controller.listAgents);
+  router.get('/agents/:id', controller.getAgent);
+  router.get('/teams', controller.listTeams);
+  router.get('/teams/:id', controller.getTeam);
+  router.get('/workflows', controller.listWorkflows);
+  router.get('/workflows/:id', controller.getWorkflow);
+  router.get('/expansions', controller.listExpansions);
+
+  return router;
+};

--- a/services/saas/src/routes/projects.js
+++ b/services/saas/src/routes/projects.js
@@ -1,0 +1,12 @@
+const express = require('express');
+
+const createProjectsController = require('../controllers/projects-controller');
+
+module.exports = function createProjectsRouter(options = {}) {
+  const router = express.Router();
+  const controller = createProjectsController(options);
+
+  router.post('/', controller.createProjectPlan);
+
+  return router;
+};

--- a/services/saas/src/server.js
+++ b/services/saas/src/server.js
@@ -1,0 +1,24 @@
+const http = require('node:http');
+const path = require('node:path');
+
+const createApp = require('./app');
+
+async function start() {
+  const port = Number.parseInt(process.env.PORT, 10) || 3000;
+  const host = process.env.HOST || '0.0.0.0';
+  const rootDir = process.env.BMAD_ROOT || path.resolve(__dirname, '../../..');
+
+  const app = await createApp({ rootDir });
+
+  const server = http.createServer(app);
+  server.listen(port, host, () => {
+    // eslint-disable-next-line no-console
+    console.log(`BMAD Research SaaS listening on http://${host}:${port}`);
+  });
+}
+
+start().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to start SaaS service:', error);
+  process.exit(1);
+});

--- a/services/saas/src/services/catalog-service.js
+++ b/services/saas/src/services/catalog-service.js
@@ -1,0 +1,656 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const { extractYamlFromAgent } = require('../../../../tools/lib/yaml-utils');
+const { toCamelCase, sortByLocale } = require('../utils/object-utils');
+
+module.exports = function createCatalogService(options = {}) {
+  const rootDir = options.rootDir || path.resolve(__dirname, '../../../..');
+  const coreDir = path.join(rootDir, 'bmad-core');
+  const expansionsDir = path.join(rootDir, 'expansion-packs');
+
+  const caches = {
+    expansions: null,
+    agents: new Map(),
+    teams: new Map(),
+    workflows: new Map(),
+  };
+
+  async function fileExists(filePath) {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function safeReadDir(dirPath) {
+    try {
+      return await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+  }
+
+  async function loadExpansionPacks() {
+    if (caches.expansions) return caches.expansions;
+
+    const entries = await safeReadDir(expansionsDir);
+    const packs = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const packPath = path.join(expansionsDir, entry.name);
+      const configPath = path.join(packPath, 'config.yaml');
+      let config = {};
+      if (await fileExists(configPath)) {
+        const content = await fs.readFile(configPath, 'utf8');
+        config = yaml.load(content) || {};
+      }
+      packs.push({
+        id: entry.name,
+        name: config.name || entry.name,
+        version: config.version || null,
+        description: config.description || null,
+        compatibility: config.compatibility || {},
+        extends: config.extends || [],
+        agents: config.agents || [],
+        workflows: config.workflows || [],
+        templates: config.templates || [],
+        dependencies: config.dependencies || [],
+        teams: config.teams || [],
+        path: packPath,
+        config,
+      });
+    }
+
+    caches.expansions = packs;
+    return packs;
+  }
+
+  function normaliseSource(source) {
+    if (!source) return null;
+    if (source === 'core') {
+      return { type: 'core', source: 'core' };
+    }
+    if (source.startsWith('expansion:')) {
+      const packId = source.split(':')[1];
+      return { type: 'expansion', source, packId };
+    }
+    // allow passing the folder or config name directly
+    return { type: 'expansion', source: `expansion:${source}`, packId: source };
+  }
+
+  function buildAgentSummary(agent) {
+    return {
+      id: agent.id,
+      name: agent.name,
+      title: agent.title,
+      role: agent.role,
+      focus: agent.focus,
+      whenToUse: agent.whenToUse,
+      icon: agent.icon,
+      source: agent.source,
+      expansionPack: agent.expansionPack,
+      summary: agent.summary,
+      commandCount: agent.commands.length,
+      dependencyTotals: agent.dependencySummary.totalCount,
+    };
+  }
+
+  function parseCommands(rawCommands) {
+    if (!Array.isArray(rawCommands)) return [];
+    const commands = [];
+    for (const item of rawCommands) {
+      if (!item) continue;
+      if (typeof item === 'string') {
+        const parts = item.split(' - ');
+        const command = parts.shift();
+        commands.push({
+          command: command?.trim() || item.trim(),
+          description: parts.length ? parts.join(' - ').trim() : null,
+        });
+        continue;
+      }
+      if (typeof item === 'object') {
+        const [commandKey, description] = Object.entries(item)[0] || [];
+        if (commandKey) {
+          commands.push({
+            command: String(commandKey).trim(),
+            description: typeof description === 'string' ? description.trim() : null,
+          });
+        }
+      }
+    }
+    return commands;
+  }
+
+  function summariseDependencies(dependencies = {}) {
+    const summary = { totalCount: 0 };
+    for (const [key, values] of Object.entries(dependencies)) {
+      const normalisedKey = toCamelCase(key);
+      const items = Array.isArray(values) ? values.map((value) => (typeof value === 'string' ? value : JSON.stringify(value))) : [];
+      summary[normalisedKey] = {
+        items,
+        count: items.length,
+      };
+      summary.totalCount += items.length;
+    }
+    return summary;
+  }
+
+  async function loadAgentFromPath(filePath, sourceMeta) {
+    const cacheKey = `${sourceMeta.source}|${filePath}`;
+    if (caches.agents.has(cacheKey)) {
+      return caches.agents.get(cacheKey);
+    }
+
+    const content = await fs.readFile(filePath, 'utf8');
+    const yamlContent = extractYamlFromAgent(content);
+    const config = yamlContent ? yaml.load(yamlContent) || {} : {};
+
+    const agentInfo = config.agent || {};
+    const persona = config.persona || {};
+    const rootPrinciples = Array.isArray(config.core_principles) ? config.core_principles : [];
+    const personaPrinciples = Array.isArray(persona.core_principles) ? persona.core_principles : [];
+    const commands = parseCommands(config.commands);
+    const dependencySummary = summariseDependencies(config.dependencies);
+
+    const agent = {
+      id: agentInfo.id || path.basename(filePath, path.extname(filePath)),
+      name: agentInfo.name || agentInfo.title || persona.role || agentInfo.id,
+      title: agentInfo.title || null,
+      icon: agentInfo.icon || null,
+      role: persona.role || null,
+      style: persona.style || null,
+      identity: persona.identity || null,
+      focus: persona.focus || null,
+      whenToUse: agentInfo.whenToUse || null,
+      summary: agentInfo.whenToUse || persona.focus || persona.role || null,
+      activationInstructions: config['activation-instructions'] || config.activationInstructions || [],
+      requestResolution: config['REQUEST-RESOLUTION'] || config.requestResolution || null,
+      ideFileResolution: config['IDE-FILE-RESOLUTION'] || config.ideFileResolution || null,
+      commands,
+      dependencySummary,
+      content,
+      config,
+      source: sourceMeta.source,
+      expansionPack: sourceMeta.packId || null,
+      relativePath: path.relative(rootDir, filePath),
+      corePrinciples: [...new Set([...rootPrinciples, ...personaPrinciples])],
+    };
+
+    caches.agents.set(cacheKey, agent);
+    return agent;
+  }
+
+  async function loadAgentsFromDir(dirPath, sourceMeta) {
+    const entries = await safeReadDir(dirPath);
+    const agents = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+      const filePath = path.join(dirPath, entry.name);
+      try {
+        const agent = await loadAgentFromPath(filePath, sourceMeta);
+        agents.push(buildAgentSummary(agent));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(`Failed to load agent ${entry.name}:`, error.message);
+      }
+    }
+    return sortByLocale(agents, (item) => item.name || item.id);
+  }
+
+  async function findAgent(agentId, sourceHint) {
+    if (sourceHint) {
+      const sourceMeta = normaliseSource(sourceHint);
+      if (sourceMeta?.type === 'core') {
+        const filePath = path.join(coreDir, 'agents', `${agentId}.md`);
+        if (await fileExists(filePath)) {
+          return { filePath, sourceMeta };
+        }
+        return null;
+      }
+      if (sourceMeta?.type === 'expansion') {
+        const packs = await loadExpansionPacks();
+        const pack = packs.find((item) => item.id === sourceMeta.packId);
+        if (!pack) return null;
+        const filePath = path.join(pack.path, 'agents', `${agentId}.md`);
+        if (await fileExists(filePath)) {
+          return { filePath, sourceMeta };
+        }
+        return null;
+      }
+    }
+
+    // search expansion packs first
+    const packs = await loadExpansionPacks();
+    for (const pack of packs) {
+      const filePath = path.join(pack.path, 'agents', `${agentId}.md`);
+      if (await fileExists(filePath)) {
+        return { filePath, sourceMeta: { type: 'expansion', source: `expansion:${pack.id}`, packId: pack.id } };
+      }
+    }
+
+    // fallback to core
+    const corePath = path.join(coreDir, 'agents', `${agentId}.md`);
+    if (await fileExists(corePath)) {
+      return { filePath: corePath, sourceMeta: { type: 'core', source: 'core' } };
+    }
+
+    return null;
+  }
+
+  function buildTeamSummary(team) {
+    return {
+      id: team.id,
+      name: team.name,
+      description: team.description,
+      domain: team.domain,
+      useCase: team.useCase,
+      source: team.source,
+      expansionPack: team.expansionPack,
+      hierarchy: team.hierarchy,
+      totalMembers: team.members.length,
+    };
+  }
+
+  function normaliseTeamScaling(rawScaling = {}) {
+    const result = {};
+    for (const [key, value] of Object.entries(rawScaling)) {
+      const camelKey = toCamelCase(key);
+      result[camelKey] = {
+        key,
+        totalAgents: value?.total_agents ?? null,
+        description: value?.description || null,
+        specialistInstances: value?.specialist_instances ?? null,
+        reviewerInstances: value?.reviewer_instances ?? null,
+      };
+    }
+    return result;
+  }
+
+  function normaliseTeam(data, sourceMeta) {
+    const teamInfo = data.team || {};
+    return {
+      id: teamInfo.id,
+      name: teamInfo.name,
+      version: teamInfo.version || null,
+      description: teamInfo.description || null,
+      domain: teamInfo.domain || null,
+      useCase: teamInfo.use_case || null,
+      members: Array.isArray(data.members) ? data.members : [],
+      hierarchy: Array.isArray(data.hierarchy) ? data.hierarchy : [],
+      collaborationPatterns: data.collaboration_patterns || {},
+      teamScaling: normaliseTeamScaling(data.team_scaling || {}),
+      qualityAssurance: data.quality_assurance || {},
+      setupGuide: data.setup_guide || {},
+      source: sourceMeta.source,
+      expansionPack: sourceMeta.packId || null,
+      relativePath: path.relative(rootDir, sourceMeta.filePath),
+    };
+  }
+
+  async function loadTeamFromPath(filePath, sourceMeta) {
+    const cacheKey = `${sourceMeta.source}|${filePath}`;
+    if (caches.teams.has(cacheKey)) return caches.teams.get(cacheKey);
+
+    const content = await fs.readFile(filePath, 'utf8');
+    const data = yaml.load(content) || {};
+    const team = normaliseTeam({ ...data, content }, { ...sourceMeta, filePath });
+    team.content = content;
+    caches.teams.set(cacheKey, team);
+    return team;
+  }
+
+  async function loadTeamsFromDir(dirPath, sourceMeta) {
+    const entries = await safeReadDir(dirPath);
+    const teams = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.yaml')) continue;
+      const filePath = path.join(dirPath, entry.name);
+      try {
+        const team = await loadTeamFromPath(filePath, sourceMeta);
+        teams.push(buildTeamSummary(team));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(`Failed to load team ${entry.name}:`, error.message);
+      }
+    }
+    return sortByLocale(teams, (item) => item.name || item.id);
+  }
+
+  async function findTeam(teamId, sourceHint) {
+    if (sourceHint) {
+      const sourceMeta = normaliseSource(sourceHint);
+      if (sourceMeta?.type === 'core') {
+        const filePath = path.join(coreDir, 'agent-teams', `${teamId}.yaml`);
+        if (await fileExists(filePath)) return { filePath, sourceMeta };
+        return null;
+      }
+      if (sourceMeta?.type === 'expansion') {
+        const packs = await loadExpansionPacks();
+        const pack = packs.find((item) => item.id === sourceMeta.packId);
+        if (!pack) return null;
+        const filePath = path.join(pack.path, 'agent-teams', `${teamId}.yaml`);
+        if (await fileExists(filePath)) return { filePath, sourceMeta };
+        return null;
+      }
+    }
+
+    const packs = await loadExpansionPacks();
+    for (const pack of packs) {
+      const filePath = path.join(pack.path, 'agent-teams', `${teamId}.yaml`);
+      if (await fileExists(filePath)) {
+        return { filePath, sourceMeta: { type: 'expansion', source: `expansion:${pack.id}`, packId: pack.id } };
+      }
+    }
+
+    const corePath = path.join(coreDir, 'agent-teams', `${teamId}.yaml`);
+    if (await fileExists(corePath)) {
+      return { filePath: corePath, sourceMeta: { type: 'core', source: 'core' } };
+    }
+
+    return null;
+  }
+
+  function buildWorkflowSummary(workflow) {
+    return {
+      id: workflow.id,
+      name: workflow.name,
+      description: workflow.description,
+      domain: workflow.metadata?.domain || null,
+      phases: workflow.phases,
+      source: workflow.source,
+      expansionPack: workflow.expansionPack,
+    };
+  }
+
+  function normaliseWorkflow(data, sourceMeta) {
+    const workflowInfo = data.workflow || {};
+    const normalisedSteps = Array.isArray(data.steps)
+      ? data.steps.map((step) => {
+          const normalisedStep = {};
+          for (const [key, value] of Object.entries(step)) {
+            normalisedStep[toCamelCase(key)] = value;
+          }
+          return normalisedStep;
+        })
+      : [];
+
+    const normalisedPhases = Array.isArray(data.phases)
+      ? data.phases.map((phase) => {
+          const normalisedPhase = {};
+          for (const [key, value] of Object.entries(phase)) {
+            normalisedPhase[toCamelCase(key)] = value;
+          }
+          return normalisedPhase;
+        })
+      : [];
+
+    const normalisedQualityGates = Array.isArray(data.quality_gates)
+      ? data.quality_gates.map((gate) => {
+          const normalisedGate = {};
+          for (const [key, value] of Object.entries(gate)) {
+            normalisedGate[toCamelCase(key)] = value;
+          }
+          return normalisedGate;
+        })
+      : [];
+
+    return {
+      id: workflowInfo.id,
+      name: workflowInfo.name,
+      version: workflowInfo.version || null,
+      description: workflowInfo.description || null,
+      metadata: data.metadata || {},
+      phases: normalisedPhases,
+      steps: normalisedSteps,
+      qualityGates: normalisedQualityGates,
+      riskManagement: data.risk_management || [],
+      successCriteria: data.success_criteria || [],
+      source: sourceMeta.source,
+      expansionPack: sourceMeta.packId || null,
+      relativePath: path.relative(rootDir, sourceMeta.filePath),
+      content: data.content,
+    };
+  }
+
+  async function loadWorkflowFromPath(filePath, sourceMeta) {
+    const cacheKey = `${sourceMeta.source}|${filePath}`;
+    if (caches.workflows.has(cacheKey)) return caches.workflows.get(cacheKey);
+
+    const content = await fs.readFile(filePath, 'utf8');
+    const data = yaml.load(content) || {};
+    const workflow = normaliseWorkflow({ ...data, content }, { ...sourceMeta, filePath });
+    caches.workflows.set(cacheKey, workflow);
+    return workflow;
+  }
+
+  async function loadWorkflowsFromDir(dirPath, sourceMeta) {
+    const entries = await safeReadDir(dirPath);
+    const workflows = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.yaml')) continue;
+      const filePath = path.join(dirPath, entry.name);
+      try {
+        const workflow = await loadWorkflowFromPath(filePath, sourceMeta);
+        workflows.push(buildWorkflowSummary(workflow));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(`Failed to load workflow ${entry.name}:`, error.message);
+      }
+    }
+    return sortByLocale(workflows, (item) => item.name || item.id);
+  }
+
+  async function findWorkflow(workflowId, sourceHint) {
+    if (sourceHint) {
+      const sourceMeta = normaliseSource(sourceHint);
+      if (sourceMeta?.type === 'core') {
+        const filePath = path.join(coreDir, 'workflows', `${workflowId}.yaml`);
+        if (await fileExists(filePath)) return { filePath, sourceMeta };
+        return null;
+      }
+      if (sourceMeta?.type === 'expansion') {
+        const packs = await loadExpansionPacks();
+        const pack = packs.find((item) => item.id === sourceMeta.packId);
+        if (!pack) return null;
+        const filePath = path.join(pack.path, 'workflows', `${workflowId}.yaml`);
+        if (await fileExists(filePath)) return { filePath, sourceMeta };
+        return null;
+      }
+    }
+
+    const packs = await loadExpansionPacks();
+    for (const pack of packs) {
+      const filePath = path.join(pack.path, 'workflows', `${workflowId}.yaml`);
+      if (await fileExists(filePath)) {
+        return { filePath, sourceMeta: { type: 'expansion', source: `expansion:${pack.id}`, packId: pack.id } };
+      }
+    }
+
+    const corePath = path.join(coreDir, 'workflows', `${workflowId}.yaml`);
+    if (await fileExists(corePath)) {
+      return { filePath: corePath, sourceMeta: { type: 'core', source: 'core' } };
+    }
+
+    return null;
+  }
+
+  return {
+    async getOverview() {
+      const [agents, teams, workflows, expansions] = await Promise.all([
+        this.listAgents(),
+        this.listTeams(),
+        this.listWorkflows(),
+        this.listExpansions(),
+      ]);
+
+      const coreAgents = agents.filter((agent) => agent.source === 'core').length;
+      const expansionAgents = agents.length - coreAgents;
+
+      return {
+        message: 'BMAD Research Framework SaaS catalog overview',
+        stats: {
+          totalAgents: agents.length,
+          coreAgents,
+          expansionAgents,
+          totalTeams: teams.length,
+          totalWorkflows: workflows.length,
+          expansionPacks: expansions.length,
+        },
+        endpoints: {
+          health: '/health',
+          catalog: '/api/catalog',
+          agents: '/api/catalog/agents',
+          teams: '/api/catalog/teams',
+          workflows: '/api/catalog/workflows',
+          expansions: '/api/catalog/expansions',
+          projectPlanning: '/api/projects',
+        },
+      };
+    },
+
+    async listAgents({ source } = {}) {
+      if (source) {
+        const sourceMeta = normaliseSource(source);
+        if (sourceMeta?.type === 'core') {
+          return loadAgentsFromDir(path.join(coreDir, 'agents'), sourceMeta);
+        }
+        if (sourceMeta?.type === 'expansion') {
+          const packs = await loadExpansionPacks();
+          const pack = packs.find((item) => item.id === sourceMeta.packId);
+          if (!pack) return [];
+          return loadAgentsFromDir(path.join(pack.path, 'agents'), { ...sourceMeta });
+        }
+      }
+
+      const coreAgents = await loadAgentsFromDir(path.join(coreDir, 'agents'), { type: 'core', source: 'core' });
+      const packs = await loadExpansionPacks();
+      const expansionAgents = [];
+      for (const pack of packs) {
+        const agents = await loadAgentsFromDir(path.join(pack.path, 'agents'), {
+          type: 'expansion',
+          source: `expansion:${pack.id}`,
+          packId: pack.id,
+        });
+        expansionAgents.push(...agents);
+      }
+
+      return sortByLocale([...coreAgents, ...expansionAgents], (item) => item.name || item.id);
+    },
+
+    async getAgent(agentId, source) {
+      const location = await findAgent(agentId, source);
+      if (!location) return null;
+      const agent = await loadAgentFromPath(location.filePath, location.sourceMeta);
+
+      return {
+        ...agent,
+        dependencySummary: agent.dependencySummary,
+      };
+    },
+
+    async listTeams({ source } = {}) {
+      if (source) {
+        const sourceMeta = normaliseSource(source);
+        if (sourceMeta?.type === 'core') {
+          return loadTeamsFromDir(path.join(coreDir, 'agent-teams'), sourceMeta);
+        }
+        if (sourceMeta?.type === 'expansion') {
+          const packs = await loadExpansionPacks();
+          const pack = packs.find((item) => item.id === sourceMeta.packId);
+          if (!pack) return [];
+          return loadTeamsFromDir(path.join(pack.path, 'agent-teams'), { ...sourceMeta });
+        }
+      }
+
+      const teams = [];
+      const coreTeamsDir = path.join(coreDir, 'agent-teams');
+      if (await fileExists(coreTeamsDir)) {
+        teams.push(
+          ...(await loadTeamsFromDir(coreTeamsDir, { type: 'core', source: 'core' })),
+        );
+      }
+      const packs = await loadExpansionPacks();
+      for (const pack of packs) {
+        const dir = path.join(pack.path, 'agent-teams');
+        if (!(await fileExists(dir))) continue;
+        const packTeams = await loadTeamsFromDir(dir, {
+          type: 'expansion',
+          source: `expansion:${pack.id}`,
+          packId: pack.id,
+        });
+        teams.push(...packTeams);
+      }
+      return sortByLocale(teams, (item) => item.name || item.id);
+    },
+
+    async getTeam(teamId, source) {
+      const location = await findTeam(teamId, source);
+      if (!location) return null;
+      const team = await loadTeamFromPath(location.filePath, location.sourceMeta);
+      return team;
+    },
+
+    async listWorkflows({ source } = {}) {
+      if (source) {
+        const sourceMeta = normaliseSource(source);
+        if (sourceMeta?.type === 'core') {
+          return loadWorkflowsFromDir(path.join(coreDir, 'workflows'), sourceMeta);
+        }
+        if (sourceMeta?.type === 'expansion') {
+          const packs = await loadExpansionPacks();
+          const pack = packs.find((item) => item.id === sourceMeta.packId);
+          if (!pack) return [];
+          return loadWorkflowsFromDir(path.join(pack.path, 'workflows'), { ...sourceMeta });
+        }
+      }
+
+      const workflows = [];
+      const coreWorkflowDir = path.join(coreDir, 'workflows');
+      if (await fileExists(coreWorkflowDir)) {
+        workflows.push(
+          ...(await loadWorkflowsFromDir(coreWorkflowDir, { type: 'core', source: 'core' })),
+        );
+      }
+      const packs = await loadExpansionPacks();
+      for (const pack of packs) {
+        const dir = path.join(pack.path, 'workflows');
+        if (!(await fileExists(dir))) continue;
+        const packWorkflows = await loadWorkflowsFromDir(dir, {
+          type: 'expansion',
+          source: `expansion:${pack.id}`,
+          packId: pack.id,
+        });
+        workflows.push(...packWorkflows);
+      }
+      return sortByLocale(workflows, (item) => item.name || item.id);
+    },
+
+    async getWorkflow(workflowId, source) {
+      const location = await findWorkflow(workflowId, source);
+      if (!location) return null;
+      const workflow = await loadWorkflowFromPath(location.filePath, location.sourceMeta);
+      return workflow;
+    },
+
+    async listExpansions() {
+      const packs = await loadExpansionPacks();
+      return packs.map((pack) => ({
+        id: pack.id,
+        name: pack.name,
+        version: pack.version,
+        description: pack.description,
+        compatibility: pack.compatibility,
+        agents: pack.agents,
+        workflows: pack.workflows,
+        templates: pack.templates,
+        dependencies: pack.dependencies,
+        teams: pack.teams,
+      }));
+    },
+  };
+};

--- a/services/saas/src/services/project-service.js
+++ b/services/saas/src/services/project-service.js
@@ -1,0 +1,365 @@
+const path = require('node:path');
+
+const createCatalogService = require('./catalog-service');
+
+const RESEARCH_PROFILES = [
+  {
+    id: 'fundamental',
+    labels: ['基础研究', '基础理论研究', 'fundamental'],
+    summary: '关注理论创新与方法论验证，需要严谨的研究设计与知识积累。',
+    emphasis: {
+      planning_configuration: '聚焦理论框架的清晰化与研究边界界定。',
+      research_preparation: '加强文献综述和知识图谱构建，确保理论扎实。',
+      execution_phase: '强调实验设计的可重复性与数据可信度。',
+    },
+    metrics: ['理论创新度', '方法论严谨性', '学术影响力'],
+    riskFocus: ['模型假设偏差', '实验验证困难'],
+    knowledgeFocus: '加强基础理论文献与前沿研究成果的整合。',
+    recommendedTeamScaling: 'standardConfig',
+  },
+  {
+    id: 'applied',
+    labels: ['应用研究', '工程技术攻关', 'applied research', '工程研究'],
+    summary: '面向实际应用问题，强调跨专业协作与成果转化。',
+    emphasis: {
+      planning_configuration: '突出需求分析与应用场景定义。',
+      execution_phase: '强化多专业团队的协同执行与进度管理。',
+      reporting_phase: '聚焦成果转化方案与可实施性评估。',
+    },
+    metrics: ['解决方案成熟度', '成果转化潜力', '项目交付及时性'],
+    riskFocus: ['需求变更', '资源协调', '技术集成风险'],
+    knowledgeFocus: '结合行业标准、专利与应用案例库。',
+    recommendedTeamScaling: 'fullConfig',
+  },
+  {
+    id: 'social-science',
+    labels: ['社会科学', '社会科学研究', 'social science'],
+    summary: '强调定性与定量结合，注重研究对象与伦理合规。',
+    emphasis: {
+      planning_configuration: '完善研究问题界定与样本设计。',
+      research_preparation: '强化数据收集方案与伦理审查流程。',
+      reporting_phase: '突出洞察解读与政策建议。',
+    },
+    metrics: ['样本代表性', '研究伦理合规', '社会影响力'],
+    riskFocus: ['样本偏差', '数据隐私风险'],
+    knowledgeFocus: '补充领域调研报告、问卷与案例研究模板。',
+    recommendedTeamScaling: 'standardConfig',
+  },
+  {
+    id: 'default',
+    labels: ['default'],
+    summary: '通用科研项目配置，兼顾规划、执行与成果产出。',
+    emphasis: {
+      planning_configuration: '确保目标明确与资源配置到位。',
+      research_preparation: '构建充足的知识支撑体系。',
+      execution_phase: '保持多团队协作节奏。',
+      reporting_phase: '形成标准化成果交付物。',
+    },
+    metrics: ['里程碑达成度', '知识积累完整性', '成果交付质量'],
+    riskFocus: ['跨团队协作', '时间进度控制'],
+    knowledgeFocus: '保持知识库、模板与任务的持续更新。',
+    recommendedTeamScaling: 'standardConfig',
+  },
+];
+
+function selectProfile(researchType) {
+  const input = (researchType || '').trim().toLowerCase();
+  if (!input) return RESEARCH_PROFILES.find((profile) => profile.id === 'default');
+  return (
+    RESEARCH_PROFILES.find((profile) =>
+      profile.labels.some((label) => input.includes(label.toLowerCase())),
+    ) || RESEARCH_PROFILES.find((profile) => profile.id === 'default')
+  );
+}
+
+function normaliseObjectives(objectives) {
+  if (!objectives) return [];
+  if (Array.isArray(objectives)) return objectives.filter(Boolean);
+  return String(objectives)
+    .split(/[\n,;]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function extractInitializationSteps(setupGuide = {}) {
+  const { project_initialization: projectInit } = setupGuide;
+  if (!projectInit) return [];
+  if (Array.isArray(projectInit)) return projectInit;
+  if (typeof projectInit === 'object') {
+    return Object.keys(projectInit)
+      .sort((a, b) => Number(a) - Number(b))
+      .map((key) => projectInit[key])
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function chooseTeamScaling(teamScaling = {}, requestedSize, preferredKey) {
+  const entries = Object.entries(teamScaling).map(([key, value]) => ({ key, ...value }));
+  if (!entries.length) {
+    return { selected: null, options: teamScaling, rationale: '团队配置没有预设规模建议。' };
+  }
+
+  let selected = null;
+  if (preferredKey && teamScaling[preferredKey]) {
+    selected = { key: preferredKey, ...teamScaling[preferredKey] };
+  }
+
+  if (!selected && Number.isFinite(requestedSize)) {
+    const candidates = entries
+      .filter((entry) => Number.isFinite(entry.totalAgents))
+      .sort((a, b) => a.totalAgents - b.totalAgents);
+    for (const option of candidates) {
+      if (requestedSize <= option.totalAgents) {
+        selected = option;
+        break;
+      }
+    }
+    if (!selected && candidates.length) {
+      selected = candidates[candidates.length - 1];
+    }
+  }
+
+  if (!selected) {
+    selected = entries[0];
+  }
+
+  const rationaleParts = [];
+  if (preferredKey && selected.key === preferredKey) {
+    rationaleParts.push('按研究类型建议选择该团队规模。');
+  }
+  if (Number.isFinite(requestedSize)) {
+    rationaleParts.push(`根据期望团队规模≈${requestedSize}人进行匹配。`);
+  }
+
+  return {
+    selected,
+    options: teamScaling,
+    rationale: rationaleParts.length ? rationaleParts.join(' ') : '采用默认团队规模配置。',
+  };
+}
+
+function buildPhasePlan(workflow, profile) {
+  const stepsByPhase = workflow.steps.reduce((acc, step) => {
+    const key = step.phase;
+    if (!acc.has(key)) acc.set(key, []);
+    acc.get(key).push(step);
+    return acc;
+  }, new Map());
+
+  return workflow.phases.map((phase) => {
+    const phaseSteps = stepsByPhase.get(phase.id) || [];
+    const emphasis = profile.emphasis?.[phase.id] || profile.emphasis?.[phase.name];
+    return {
+      ...phase,
+      steps: phaseSteps,
+      emphasis: emphasis || null,
+      priority: emphasis ? 'high' : 'standard',
+    };
+  });
+}
+
+function gatherDeliverables(workflow) {
+  const deliverables = [];
+  for (const step of workflow.steps) {
+    if (!Array.isArray(step.outputs) || !step.outputs.length) continue;
+    for (const output of step.outputs) {
+      deliverables.push({
+        phase: step.phase,
+        stepId: step.id,
+        stepName: step.name,
+        agent: step.agent,
+        output,
+      });
+    }
+  }
+  return deliverables;
+}
+
+function gatherInteractionPoints(workflow) {
+  return workflow.steps
+    .filter((step) => step.interactionRequired)
+    .map((step) => ({
+      phase: step.phase,
+      stepId: step.id,
+      stepName: step.name,
+      agent: step.agent,
+      description: step.description,
+    }));
+}
+
+function parseAgentReference(reference) {
+  if (typeof reference !== 'string') return null;
+  const match = reference.match(/([a-z0-9-]+)/i);
+  return match ? match[1] : null;
+}
+
+module.exports = function createProjectService(options = {}) {
+  const rootDir = options.rootDir || path.resolve(__dirname, '../../../..');
+  const catalogService = options.catalogService || createCatalogService({ rootDir });
+  const defaultPackId = options.defaultPackId || 'bmad-research-framework';
+  const defaultTeamId = options.defaultTeamId || 'research-full-team';
+  const defaultWorkflowId = options.defaultWorkflowId || 'universal-research-workflow';
+
+  return {
+    async createProjectPlan(payload = {}) {
+      const projectName = (payload.projectName || payload.name || '未命名科研项目').trim();
+      const researchType = payload.researchType || payload.type || '通用科研';
+      const objectives = normaliseObjectives(payload.objectives || payload.goals);
+      const desiredOutcomes = normaliseObjectives(payload.desiredOutcomes || payload.expectedOutputs);
+      const timeframe = payload.timeframe || payload.timeline || null;
+      const requestedTeamSize = Number.isFinite(Number(payload.teamSize))
+        ? Number(payload.teamSize)
+        : Number.isFinite(Number(payload.expectedTeamSize))
+        ? Number(payload.expectedTeamSize)
+        : null;
+
+      const profile = selectProfile(researchType);
+
+      const expansions = await catalogService.listExpansions();
+      const expansionPack =
+        expansions.find((pack) => pack.id === defaultPackId) || expansions[0];
+
+      if (!expansionPack) {
+        const error = new Error('未找到科研框架扩展包，请先安装扩展包后再使用SaaS服务。');
+        error.status = 500;
+        throw error;
+      }
+
+      const [team, workflow] = await Promise.all([
+        catalogService.getTeam(defaultTeamId, `expansion:${expansionPack.id}`),
+        catalogService.getWorkflow(defaultWorkflowId, `expansion:${expansionPack.id}`),
+      ]);
+
+      if (!team) {
+        const error = new Error('未找到科研团队配置文件，无法生成项目方案。');
+        error.status = 500;
+        throw error;
+      }
+      if (!workflow) {
+        const error = new Error('未找到科研工作流定义，无法生成项目方案。');
+        error.status = 500;
+        throw error;
+      }
+
+      const phasePlan = buildPhasePlan(workflow, profile);
+      const deliverables = gatherDeliverables(workflow);
+      const interactionPoints = gatherInteractionPoints(workflow);
+      const scalingRecommendation = chooseTeamScaling(team.teamScaling, requestedTeamSize, profile.recommendedTeamScaling);
+
+      const agentIds = new Set();
+      for (const member of team.members) {
+        if (member.agent) agentIds.add(member.agent);
+      }
+      for (const step of workflow.steps) {
+        if (step.agent && step.agent !== 'human-user') {
+          agentIds.add(step.agent);
+        }
+        if (Array.isArray(step.subAgents)) {
+          for (const ref of step.subAgents) {
+            const parsed = parseAgentReference(ref);
+            if (parsed) agentIds.add(parsed);
+          }
+        }
+      }
+
+      const agentDetails = [];
+      for (const agentId of agentIds) {
+        let detail = await catalogService.getAgent(agentId, `expansion:${expansionPack.id}`);
+        if (!detail) {
+          detail = await catalogService.getAgent(agentId, 'core');
+        }
+        if (detail) {
+          agentDetails.push({
+            id: detail.id,
+            name: detail.name,
+            title: detail.title,
+            role: detail.role,
+            focus: detail.focus,
+            whenToUse: detail.whenToUse,
+            source: detail.source,
+            expansionPack: detail.expansionPack,
+            corePrinciples: detail.corePrinciples,
+            commandExamples: detail.commands.slice(0, 3),
+            dependencySummary: detail.dependencySummary,
+          });
+        }
+      }
+
+      const initializationSteps = extractInitializationSteps(team.setupGuide);
+      const runtimePractices = Array.isArray(team.setupGuide?.runtime_management)
+        ? team.setupGuide.runtime_management
+        : [];
+      const successMetrics = Array.isArray(team.setupGuide?.success_metrics)
+        ? team.setupGuide.success_metrics
+        : profile.metrics;
+
+      return {
+        project: {
+          name: projectName,
+          researchType,
+          profile: {
+            id: profile.id,
+            summary: profile.summary,
+            metrics: profile.metrics,
+            riskFocus: profile.riskFocus,
+            knowledgeFocus: profile.knowledgeFocus,
+          },
+          objectives,
+          desiredOutcomes,
+          timeframe: timeframe || workflow.metadata?.estimated_duration || '根据项目规划动态调整',
+        },
+        recommendedTeam: {
+          id: team.id,
+          name: team.name,
+          description: team.description,
+          domain: team.domain,
+          useCase: team.useCase,
+          hierarchy: team.hierarchy,
+          members: team.members,
+          collaborationPatterns: team.collaborationPatterns,
+          teamScaling: team.teamScaling,
+          scalingRecommendation,
+          qualityAssurance: team.qualityAssurance,
+          setupGuide: team.setupGuide,
+          initializationSteps,
+          runtimePractices,
+          successMetrics,
+        },
+        workflowPlan: {
+          id: workflow.id,
+          name: workflow.name,
+          description: workflow.description,
+          metadata: workflow.metadata,
+          phases: phasePlan,
+          steps: workflow.steps,
+          deliverables,
+          interactionPoints,
+          qualityGates: workflow.qualityGates,
+          riskManagement: workflow.riskManagement,
+          successCriteria: workflow.successCriteria,
+        },
+        agentInsights: {
+          totalAgents: agentDetails.length,
+          agents: agentDetails,
+        },
+        knowledgeSupport: {
+          expansionPack: {
+            id: expansionPack.id,
+            name: expansionPack.name,
+            description: expansionPack.description,
+          },
+          recommendedTemplates: expansionPack.templates || [],
+          recommendedWorkflows: expansionPack.workflows || [],
+          recommendedAgents: expansionPack.agents || [],
+          knowledgeFocus: profile.knowledgeFocus,
+        },
+        nextActions: [
+          `启动 ${team.members[0]?.agent || 'research-strategy-planner'}，完成项目战略规划。`,
+          initializationSteps[0] || '复盘自动配置结果并确认团队角色分工。',
+          '同步知识管理团队，建立初始文献与知识库结构。',
+        ],
+      };
+    },
+  };
+};

--- a/services/saas/src/utils/async-handler.js
+++ b/services/saas/src/utils/async-handler.js
@@ -1,0 +1,7 @@
+function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+module.exports = asyncHandler;

--- a/services/saas/src/utils/object-utils.js
+++ b/services/saas/src/utils/object-utils.js
@@ -1,0 +1,19 @@
+function toCamelCase(input) {
+  if (!input) return input;
+  return String(input)
+    .replace(/[-_]+(.)?/g, (_, chr) => (chr ? chr.toUpperCase() : ''))
+    .replace(/^(.)/, (match) => match.toLowerCase());
+}
+
+function sortByLocale(items, selector) {
+  return [...items].sort((a, b) => {
+    const aValue = selector(a) ?? '';
+    const bValue = selector(b) ?? '';
+    return String(aValue).localeCompare(String(bValue), 'zh-Hans-CN-u-co-pinyin');
+  });
+}
+
+module.exports = {
+  toCamelCase,
+  sortByLocale,
+};

--- a/tools/upgraders/v3-to-v4-upgrader.js
+++ b/tools/upgraders/v3-to-v4-upgrader.js
@@ -1,0 +1,142 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const fsExtra = require('fs-extra');
+
+class V3ToV4Upgrader {
+  constructor({ logger = console } = {}) {
+    this.logger = logger;
+  }
+
+  async upgrade(options = {}) {
+    const {
+      projectPath = process.cwd(),
+      dryRun = false,
+      backup = true,
+    } = options;
+
+    const targetPath = path.resolve(projectPath || process.cwd());
+
+    await this.assertProjectExists(targetPath);
+
+    this.logger.log(`Starting BMAD V3 → V4 upgrade for: ${targetPath}`);
+
+    const migrationPlan = await this.generateMigrationPlan(targetPath);
+
+    if (migrationPlan.actions.length === 0) {
+      this.logger.log('Project already uses the latest layout. No changes required.');
+      return;
+    }
+
+    if (dryRun) {
+      this.logger.log('Dry run enabled. Planned actions:');
+      for (const action of migrationPlan.actions) {
+        this.logger.log(`  • ${action.description}`);
+      }
+      this.logger.log('No files were modified.');
+      return;
+    }
+
+    if (backup) {
+      await this.createBackup(targetPath, migrationPlan.backupDirName);
+    }
+
+    for (const action of migrationPlan.actions) {
+      await action.execute();
+      this.logger.log(`  ✓ ${action.description}`);
+    }
+
+    this.logger.log('Upgrade complete! Review the changes before continuing.');
+  }
+
+  async assertProjectExists(projectPath) {
+    const exists = await fsExtra.pathExists(projectPath);
+    if (!exists) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+  }
+
+  async generateMigrationPlan(projectPath) {
+    const actions = [];
+
+    const legacyConfigPath = path.join(projectPath, 'bmad.config.json');
+    const modernConfigPath = path.join(projectPath, 'bmad.config.yaml');
+
+    const hasLegacyConfig = await fsExtra.pathExists(legacyConfigPath);
+    const hasModernConfig = await fsExtra.pathExists(modernConfigPath);
+
+    if (hasLegacyConfig && !hasModernConfig) {
+      const convertConfig = {
+        description: 'Convert bmad.config.json to bmad.config.yaml',
+        execute: async () => {
+          const raw = await fs.readFile(legacyConfigPath, 'utf8');
+          const parsed = JSON.parse(raw);
+          const yaml = require('js-yaml');
+          const serialized = yaml.dump(parsed, { lineWidth: 100 });
+          await fs.writeFile(modernConfigPath, serialized, 'utf8');
+        },
+      };
+
+      const removeLegacy = {
+        description: 'Remove legacy bmad.config.json',
+        execute: async () => {
+          await fs.unlink(legacyConfigPath);
+        },
+      };
+
+      actions.push(convertConfig, removeLegacy);
+    }
+
+    const legacyAgentsDir = path.join(projectPath, 'agents');
+    const newAgentsDir = path.join(projectPath, 'bmad-core', 'agents');
+
+    if (await this.shouldMoveDirectory(legacyAgentsDir, newAgentsDir)) {
+      actions.push({
+        description: 'Move agents/ to bmad-core/agents',
+        execute: () => this.moveDirectory(legacyAgentsDir, newAgentsDir),
+      });
+    }
+
+    const legacyTeamsDir = path.join(projectPath, 'teams');
+    const newTeamsDir = path.join(projectPath, 'bmad-core', 'teams');
+
+    if (await this.shouldMoveDirectory(legacyTeamsDir, newTeamsDir)) {
+      actions.push({
+        description: 'Move teams/ to bmad-core/teams',
+        execute: () => this.moveDirectory(legacyTeamsDir, newTeamsDir),
+      });
+    }
+
+    return {
+      actions,
+      backupDirName: `.bmad-backup-${Date.now()}`,
+    };
+  }
+
+  async shouldMoveDirectory(sourceDir, targetDir) {
+    const sourceExists = await fsExtra.pathExists(sourceDir);
+    if (!sourceExists) return false;
+
+    const targetExists = await fsExtra.pathExists(targetDir);
+    if (targetExists) return false;
+
+    const entries = await fs.readdir(sourceDir);
+    return entries.length > 0;
+  }
+
+  async moveDirectory(sourceDir, targetDir) {
+    await fsExtra.ensureDir(path.dirname(targetDir));
+    await fsExtra.move(sourceDir, targetDir, { overwrite: false });
+  }
+
+  async createBackup(projectPath, backupDirName) {
+    const backupRoot = path.join(projectPath, backupDirName);
+    await fsExtra.ensureDir(backupRoot);
+
+    this.logger.log(`Creating backup at ${backupRoot}`);
+    await fsExtra.copy(projectPath, backupRoot, {
+      filter: (src) => !src.includes(backupDirName),
+    });
+  }
+}
+
+module.exports = V3ToV4Upgrader;


### PR DESCRIPTION
## Summary
- add an Electron-based desktop application with catalog browsing, planner UI, and persistent preferences separate from the SaaS service
- expose preload bridges that reuse catalog and project services for offline use and provide renderer UX for exploring agents and workflows
- document desktop workflows, add npm scripts, and ignore desktop build artefacts

## Testing
- npm run build
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68d7456b99d48330a6e1a501a83055a7